### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ python:
   - 3.2
   - 3.3
   - pypy
-install: pip install -r test-requirements.txt
+install:
+  - pip install -r test-requirements.txt
+  - python setup.py install
 script: nosetests -d

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
+-r requirements.txt
 nose
 mock>=1.0
 coverage>=3.6


### PR DESCRIPTION
This fix building with travis.

* 	64dfd36 was because the dependencies for the testing version do not contain every deps from the "normal" version
* 		33a3ce3 was needed because of `cliff.tests.test_complete.test_complete_command_take_action` needed that the entry point for bash is available. This was a quick way to fix it, maybe there is a better one to get around it